### PR TITLE
Add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ build/
 *.log
 *.tmp
 *.bak
+
+# Environment files (secrets)
+.env
+.env.*


### PR DESCRIPTION
## Summary
- Add `.env` and `.env.*` patterns to gitignore to protect secrets from accidental commits

## Test plan
- [x] Verify `.env` file is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)